### PR TITLE
Consistent nud invocation.

### DIFF
--- a/ramnud-run
+++ b/ramnud-run
@@ -63,7 +63,7 @@ if [ -f /ramdisk/walletB.dat ]; then
         if [ -f /ramdisk/walletS.dat ]; then
                 echo "Starting nud with wallets on ramdisk"
                 ln -s /ramdisk/walletS.dat ~/.nu/walletS.dat
-                ~/bin/nud
+                nud
         else
                 echo "/ramdisk/walletS.dat doesn't exist"
         fi


### PR DESCRIPTION
README.md warns that nud should be in an accessible place such as /bin and the ramnud-stop script assumes as much. However, ramnud-run was previously looking at ~/bin/nud which has now been changed.
